### PR TITLE
fix tests, updated docker client library needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,16 @@ $(WEBUI)/node_modules:
 	(cd $(WEBUI) && npm install)
 
 $(GOSRC)/golang/lint/golint:
-	go get github.com/golang/lint/golint
+	go get -u github.com/golang/lint/golint
 
 $(GOSRC)/fsouza/go-dockerclient:
-	go get github.com/fsouza/go-dockerclient
+	go get -u github.com/fsouza/go-dockerclient
 
 $(GOSRC)/gorilla/mux:
-	go get github.com/gorilla/mux
+	go get -u github.com/gorilla/mux
 
 $(GOSRC)/pborman/uuid:
-	go get github.com/pborman/uuid
+	go get -u github.com/pborman/uuid
 
 $(EUDATSRC)/EpicPID:
 	git clone https://github.com/EUDAT-GEF/EpicPID

--- a/backend-docker/dckr/dckr_test.go
+++ b/backend-docker/dckr/dckr_test.go
@@ -29,18 +29,32 @@ func TestClient(t *testing.T) {
 		t.Error("")
 		t.Error(errstr)
 		t.Fail()
+		return
 	}
 
 	containerID := executeImage(c, img.ID, t)
-	log.Println("started container: ", containerID)
+	log.Println("executed container: ", containerID)
 
-	containers := listContainers(c, t)
-	if len(containers) == 0 {
+	containerList := listContainers(c, t)
+	if len(containerList) == 0 {
 		t.Error("cannot find any containers")
 		t.Fail()
+		return
 	}
 
-	inspectContainer(c, containers[0].ID, t)
+	found := false
+	for _, container := range containerList {
+		if container.ID == containerID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("cannot find the executed container in the list of all containers")
+		t.Fail()
+		return
+	}
+
+	inspectContainer(c, containerID, t)
 }
 
 func newClient(t *testing.T) Client {


### PR DESCRIPTION
The tests failed because the fsouza/go-dockerclient needed to be updated. Please run: `go get -u github.com/fsouza/go-dockerclient` on your machine.

This PR can break some of the existing code, but I think it's how it should work.