### PR TITLE
Image import from tar archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ webui:
 
 containers:
 	(cd $(INTERNALSERVICES)/volume-stage-in && docker build -t volume-stage-in .)
-	(cd $(INTERNALSERVICES)/volume-filelist && GOOS=linux GOARCH=amd64 go build && docker build -t volume-filelist .)
+	(cd $(INTERNALSERVICES)/volume-filelist && GOOS=linux GOARCH=amd64 go build -ldflags -s && docker build -t volume-filelist .)
 	(cd $(INTERNALSERVICES)/copy-from-volume && docker build -t copy-from-volume .)
 
 backend:
 	$(GOPATH)/bin/golint ./...
 	go vet ./...
-	go test ./...
-	go build ./...
+	go test -ldflags -s ./...
+	go build -ldflags -s ./...
 
 dependencies: $(WEBUI)/node_modules $(GOSRC)/golang/lint/golint $(GOSRC)/fsouza/go-dockerclient $(GOSRC)/gorilla/mux $(GOSRC)/pborman/uuid $(GOSRC)/gopkg.in/gorp.v1 $(GOSRC)github.com/mattn/go-sqlite3
 
@@ -46,6 +46,6 @@ webui_dev_server:
 	(cd $(WEBUI) && node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.devel.js)
 
 run_gef:
-	(cd backend-docker && go run main.go)
+	(cd backend-docker && go run -ldflags -s main.go)
 
 .PHONY: build dependencies webui frontend backend webui_dev_server run_frontend run_backend clean

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GOSRC = ./../..
 EUDATSRC = ./..
 WEBUI = frontend/webui
 INTERNALSERVICES = services/_internal
+GOFLAGS=-ldflags -s
 
 build: dependencies webui frontend containers backend
 
@@ -10,14 +11,14 @@ webui:
 
 containers:
 	(cd $(INTERNALSERVICES)/volume-stage-in && docker build -t volume-stage-in .)
-	(cd $(INTERNALSERVICES)/volume-filelist && GOOS=linux GOARCH=amd64 go build -ldflags -s && docker build -t volume-filelist .)
+	(cd $(INTERNALSERVICES)/volume-filelist && GOOS=linux GOARCH=amd64 go build $(GOFLAGS) && docker build -t volume-filelist .)
 	(cd $(INTERNALSERVICES)/copy-from-volume && docker build -t copy-from-volume .)
 
 backend:
 	$(GOPATH)/bin/golint ./...
 	go vet ./...
-	go test -ldflags -s ./...
-	go build -ldflags -s ./...
+	go test $(GOFLAGS) ./...
+	go build $(GOFLAGS) ./...
 
 dependencies: $(WEBUI)/node_modules $(GOSRC)/golang/lint/golint $(GOSRC)/fsouza/go-dockerclient $(GOSRC)/gorilla/mux $(GOSRC)/pborman/uuid $(GOSRC)/gopkg.in/gorp.v1 $(GOSRC)github.com/mattn/go-sqlite3
 
@@ -46,6 +47,6 @@ webui_dev_server:
 	(cd $(WEBUI) && node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.devel.js)
 
 run_gef:
-	(cd backend-docker && go run -ldflags -s main.go)
+	(cd backend-docker && go run $(GOFLAGS) main.go)
 
 .PHONY: build dependencies webui frontend backend webui_dev_server run_frontend run_backend clean

--- a/backend-docker/db/db.go
+++ b/backend-docker/db/db.go
@@ -16,7 +16,6 @@ const SQLiteDataBasePath = "gef_db.bin"
 // Db is used to keep DbMap
 type Db struct{ gorp.DbMap }
 
-
 // JobTable stores the information about a service execution (used to store data in a database)
 type JobTable struct {
 	ID           string

--- a/backend-docker/pier/internal/dckr/dckr.go
+++ b/backend-docker/pier/internal/dckr/dckr.go
@@ -520,3 +520,16 @@ func (c Client) UploadFile2Container(containerID, srcPath string, dstPath string
 	err = c.c.UploadToContainer(containerID, opts)
 	return err
 }
+
+
+func (c *Client) LoadImageFromTar(imageid string) error {
+	tar, err := os.Open("~/image2.tar")
+	if err != nil {
+		return err
+	}
+	opts := docker.LoadImageOptions{InputStream: tar}
+	if err = c.c.LoadImage(opts); err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend-docker/pier/pier.go
+++ b/backend-docker/pier/pier.go
@@ -41,6 +41,8 @@ func NewPier(cfgList []def.DockerConfig, tmpDir string, dataBase *db.Db) (*Pier,
 		db:     dataBase,
 		tmpDir: tmpDir,
 	}
+
+	//docker.LoadImageFromTar("sdsdsd")
 	return &pier, nil
 }
 

--- a/backend-docker/server/api.go
+++ b/backend-docker/server/api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/EUDAT-GEF/GEF/backend-docker/def"
 	"github.com/EUDAT-GEF/GEF/backend-docker/pier"
 	"github.com/gorilla/mux"
-	"fmt"
 )
 
 const (
@@ -153,7 +152,7 @@ func (s *Server) buildImageHandler(w http.ResponseWriter, r *http.Request) {
 		if part.FileName() == "" {
 			continue
 		}
-		fmt.Println(part.FileName())
+
 		dst, err := os.Create(filepath.Join(buildDir, part.FileName()))
 		if err != nil {
 			Response{w}.ServerError("while creating file to save file part ", err)

--- a/backend-docker/server/api.go
+++ b/backend-docker/server/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/EUDAT-GEF/GEF/backend-docker/def"
 	"github.com/EUDAT-GEF/GEF/backend-docker/pier"
 	"github.com/gorilla/mux"
+	"fmt"
 )
 
 const (
@@ -152,6 +153,7 @@ func (s *Server) buildImageHandler(w http.ResponseWriter, r *http.Request) {
 		if part.FileName() == "" {
 			continue
 		}
+		fmt.Println(part.FileName())
 		dst, err := os.Create(filepath.Join(buildDir, part.FileName()))
 		if err != nil {
 			Response{w}.ServerError("while creating file to save file part ", err)

--- a/frontend/webui/package.json
+++ b/frontend/webui/package.json
@@ -30,7 +30,7 @@
     "react": "^15.4.2",
     "react-bootstrap": "^0.30.7",
     "react-dom": "^15.4.2",
-    "react-dropzone-component": "^1.1.0",
+    "react-dropzone-component": "^1.4.1",
     "react-redux": "^5.0.3",
     "react-router": "^3.0.2",
     "react-router-bootstrap": "^0.23.1",

--- a/frontend/webui/src/components/Files.jsx
+++ b/frontend/webui/src/components/Files.jsx
@@ -16,10 +16,13 @@ class Files extends React.Component {
     constructor(props) {
         super(props);
 
+       
+
         this.djsConfig = {
             addRemoveLinks: true,
             autoProcessQueue: false,
             uploadMultiple: true,
+            parallelUploads: 999,
             previewTemplate: ReactDOMServer.renderToStaticMarkup(
                 <div className="dz-preview dz-file-preview">
                     <div className="dz-filename"><span data-dz-name="true"></span></div>

--- a/frontend/webui/src/components/Files.jsx
+++ b/frontend/webui/src/components/Files.jsx
@@ -23,6 +23,7 @@ class Files extends React.Component {
             autoProcessQueue: false,
             uploadMultiple: true,
             parallelUploads: 999,
+            maxFilesize: 4000,
             previewTemplate: ReactDOMServer.renderToStaticMarkup(
                 <div className="dz-preview dz-file-preview">
                     <div className="dz-filename"><span data-dz-name="true"></span></div>

--- a/frontend/webui/src/components/Jobs.jsx
+++ b/frontend/webui/src/components/Jobs.jsx
@@ -30,31 +30,37 @@ class Jobs extends React.Component {
     }
 
     render() {
-        return (
-            <div>
-                <h3>Browse Jobs</h3>
-                <h4>All jobs</h4>
-                <Header/>
-                { this.props.jobs.map((job) => {
-                    let service = null;
-                    for (var i = 0; i < this.props.services.length; ++i) {
-                        if (job.ServiceID == this.props.services[i].ID) {
-                            service = this.props.services[i];
-                            break;
+        if (this.props.jobs) {
+            return (
+                <div>
+                    <h3>Browse Jobs</h3>
+                    <h4>All jobs</h4>
+                    <Header/>
+                    { this.props.jobs.map((job) => {
+                        let service = null;
+                        for (var i = 0; i < this.props.services.length; ++i) {
+                            if (job.ServiceID == this.props.services[i].ID) {
+                                service = this.props.services[i];
+                                break;
+                            }
                         }
-                    }
-                    const serviceName = (service && service.Name && service.Name.length) ? service.Name :
-                        (service && service.ID && service.ID.length) ? service.ID : "unknown service";
-                    const title = "Job from " + serviceName;
+                        const serviceName = (service && service.Name && service.Name.length) ? service.Name :
+                            (service && service.ID && service.ID.length) ? service.ID : "unknown service";
+                        const title = "Job from " + serviceName;
 
-                    if (job.ID === this.props.params.id) {
-                        return <Job key={job.ID} job={job} service={service} title={title}/>
-                    } else {
-                        return <JobRow key={job.ID} job={job} title={title}/>
-                    }
-                })}
-            </div>
-        );
+                        if (job.ID === this.props.params.id) {
+                            return <Job key={job.ID} job={job} service={service} title={title}/>
+                        } else {
+                            return <JobRow key={job.ID} job={job} title={title}/>
+                        }
+                    })}
+                </div>
+            );
+        } else {
+            return (
+                <div><h4>No jobs found</h4></div>
+            )
+        }
     }
 }
 

--- a/frontend/webui/src/components/Services.jsx
+++ b/frontend/webui/src/components/Services.jsx
@@ -41,27 +41,35 @@ class Services extends React.Component {
     }
 
     render() {
-        console.log("The id of selected service is:", this.props.params.id);
+        if (this.props.services) {
+            return (
+                <div>
+                    <h3>Browse Services</h3>
+                    <h4>All Services</h4>
+                    <Header/>
+                    { this.props.services.map((service) => {
+                        if (service.ID === this.props.params.id) {
+                            return <Service key={service.ID} service={service} fetchService={this.fetchService}
+                                            selectedService={this.props.selectedService}
+                                            handleSubmit={this.handleSubmit} volumes={this.props.volumes}/>;
+                        } else {
+                            const isGef = service.Input && service.Output;
+                            return isGef ? <ServiceRow key={service.ID} service={service}/> : false;
+                        }
+                    })}
+                    { this.props.services.map((service) => {
+                        const isGef = service.Input && service.Output;
+                        return isGef ? false : <ImageRow key={service.ID} image={service}/>;
+                    })}
+                </div>
+            )
+        }
+        else {
+            return (
+                <div><h4>No services found</h4></div>
+            )
+        }
 
-        return (
-            <div>
-                <h3>Browse Services</h3>
-                <h4>All Services</h4>
-                <Header/>
-                { this.props.services.map((service) => {
-                    if (service.ID === this.props.params.id) {
-                        return <Service key={service.ID} service={service} fetchService={this.fetchService} selectedService={this.props.selectedService} handleSubmit={this.handleSubmit} volumes={this.props.volumes}/>;
-                    } else {
-                        const isGef = service.Input.length > 0 && service.Output.length > 0;
-                        return isGef ? <ServiceRow key={service.ID} service={service} /> : false;
-                    }
-                })}
-                { this.props.services.map((service) => {
-                    const isGef = service.Input.length > 0 && service.Output.length > 0;
-                    return isGef ? false : <ImageRow key={service.ID} image={service} />;
-                })}
-            </div>
-        );
     }
 
 }


### PR DESCRIPTION
Image import from tar archives has been implemented. Metadata is extracted from Manifest.json, since there is a problem with the Docker remote API (https://github.com/fsouza/go-dockerclient/issues/645#issuecomment-291251066). Makefile has been modified to work on Mac (the last update made go partly incompatible with the latest XCode). Services.jsx and Jobs.jsx do not throw exceptions when an empty list is found, instead we show a simple message. Updated React-Dropzone component, but it still cannot handle correctly multiple file upload: uploading is done in chunks of two files (by default), ImageBuild fails, if a Dockerfile is not in the first chunk (has to be investigated https://github.com/EUDAT-GEF/GEF/issues/74).