### PR TITLE
Resource usage limits for docker

### DIFF
--- a/backend-docker/config.json
+++ b/backend-docker/config.json
@@ -17,10 +17,10 @@
 		"Address": ""
 	},
 	"Limits": {
-        "CpuShares": 1024,
-        "CpuPeriod": 100000,
-        "CpuQuota": 50000,
-        "Memory":     100024000,
-        "MemorySwap": 150024000
+		"CpuShares": 1024,
+		"CpuPeriod": 100000,
+		"CpuQuota": 50000,
+		"Memory":     100024000,
+		"MemorySwap": 150024000
 	}
 }

--- a/backend-docker/config.json
+++ b/backend-docker/config.json
@@ -15,5 +15,12 @@
 	},
 	"EventSystem": {
 		"Address": ""
+	},
+	"Limits": {
+        "CpuShares": 1024,
+        "CpuPeriod": 100000,
+        "CpuQuota": 50000,
+        "Memory":     100024000,
+        "MemorySwap": 150024000
 	}
 }

--- a/backend-docker/def/config.go
+++ b/backend-docker/def/config.go
@@ -39,10 +39,10 @@ type EventSystemConfig struct {
 
 // LimitsConfig keeps the configuration options to limit resources used by a docker container while its execution
 type LimitConfig struct {
-	CpuShares int64
-	CpuPeriod int64
-	CpuQuota int64
-	Memory	int64
+	CpuShares  int64
+	CpuPeriod  int64
+	CpuQuota   int64
+	Memory     int64
 	MemorySwap int64
 }
 

--- a/backend-docker/def/config.go
+++ b/backend-docker/def/config.go
@@ -15,6 +15,7 @@ type Configuration struct {
 	// TmpDir is the directory to keep session files in
 	// If the path is relative, it will be used as a subfolder of the system temporary directory
 	TmpDir string
+	Limits LimitConfig
 }
 
 // DockerConfig configuration for building docker clients
@@ -34,6 +35,15 @@ type ServerConfig struct {
 // EventSystemConfig keeps the configuration options needed to make an EventSystem
 type EventSystemConfig struct {
 	Address string
+}
+
+// LimitsConfig keeps the configuration options to limit resources used by a docker container while its execution
+type LimitConfig struct {
+	CpuShares int64
+	CpuPeriod int64
+	CpuQuota int64
+	Memory	int64
+	MemorySwap int64
 }
 
 func (c DockerConfig) String() string {

--- a/backend-docker/main.go
+++ b/backend-docker/main.go
@@ -30,7 +30,7 @@ func main() {
 	defer d.Db.Close()
 
 	var p *pier.Pier
-	p, err = pier.NewPier(config.Docker, config.TmpDir, &d)
+	p, err = pier.NewPier(config.Docker, config.TmpDir, config.Limits, &d)
 	p.PopulateServiceTable()
 	if err != nil {
 		log.Fatal("FATAL: ", def.Err(err, "Cannot create Pier"))

--- a/backend-docker/pier/internal/dckr/dckr.go
+++ b/backend-docker/pier/internal/dckr/dckr.go
@@ -288,11 +288,11 @@ func (c Client) StartImage(id ImageID, cmdArgs []string, binds []VolBind, limits
 	config.AttachStdout = true
 	config.AttachStderr = true
 	hc := docker.HostConfig{
-		Binds:   bs,
-		CPUShares: limits.CpuShares,
-		CPUPeriod: limits.CpuPeriod,
-		CPUQuota: limits.CpuQuota,
-		Memory: limits.Memory,
+		Binds:      bs,
+		CPUShares:  limits.CpuShares,
+		CPUPeriod:  limits.CpuPeriod,
+		CPUQuota:   limits.CpuQuota,
+		Memory:     limits.Memory,
 		MemorySwap: limits.MemorySwap,
 	}
 

--- a/backend-docker/pier/internal/dckr/dckr.go
+++ b/backend-docker/pier/internal/dckr/dckr.go
@@ -259,7 +259,7 @@ func (c *Client) BuildImage(dirpath string) (Image, error) {
 }
 
 // StartImage takes a docker image, creates a container and starts it
-func (c Client) StartImage(id ImageID, cmdArgs []string, binds []VolBind) (ContainerID, *bytes.Buffer, error) {
+func (c Client) StartImage(id ImageID, cmdArgs []string, binds []VolBind, limits def.LimitConfig) (ContainerID, *bytes.Buffer, error) {
 	var stdout bytes.Buffer
 
 	if id == "" {
@@ -287,9 +287,13 @@ func (c Client) StartImage(id ImageID, cmdArgs []string, binds []VolBind) (Conta
 
 	config.AttachStdout = true
 	config.AttachStderr = true
-
 	hc := docker.HostConfig{
-		Binds: bs,
+		Binds:   bs,
+		CPUShares: limits.CpuShares,
+		CPUPeriod: limits.CpuPeriod,
+		CPUQuota: limits.CpuQuota,
+		Memory: limits.Memory,
+		MemorySwap: limits.MemorySwap,
 	}
 
 	cco := docker.CreateContainerOptions{
@@ -338,8 +342,8 @@ func (w *WriteMonitor) Write(bs []byte) (int, error) {
 }
 
 // ExecuteImage takes a docker image, creates a container and executes it, and waits for it to end
-func (c Client) ExecuteImage(id ImageID, cmdArgs []string, binds []VolBind, removeOnExit bool) (ContainerID, int, *bytes.Buffer, error) {
-	containerID, consoleOutput, err := c.StartImage(id, cmdArgs, binds)
+func (c Client) ExecuteImage(id ImageID, cmdArgs []string, binds []VolBind, limits def.LimitConfig, removeOnExit bool) (ContainerID, int, *bytes.Buffer, error) {
+	containerID, consoleOutput, err := c.StartImage(id, cmdArgs, binds, limits)
 	if err != nil {
 		return containerID, 0, consoleOutput, def.Err(err, "StartImage failed")
 	}

--- a/backend-docker/pier/staging.go
+++ b/backend-docker/pier/staging.go
@@ -34,7 +34,7 @@ func (p *Pier) DownStreamContainerFile(volumeID string, fileLocation string, w h
 	binds := []dckr.VolBind{
 		dckr.NewVolBind(dckr.VolumeID(volumeID), "/root/volume", false),
 	}
-	containerID, _, err := p.docker.StartImage(dckr.ImageID(copyFromVolumeName), []string{filepath.Join("/root/volume/", fileLocation), "/root"}, binds)
+	containerID, _, err := p.docker.StartImage(dckr.ImageID(copyFromVolumeName), []string{filepath.Join("/root/volume/", fileLocation), "/root"}, binds, p.limits)
 
 	if err != nil {
 		return def.Err(err, "copying files from the volume to the container failed")
@@ -77,7 +77,7 @@ func (p *Pier) ListFiles(volumeID db.VolumeID, filePath string) ([]VolumeItem, e
 	}
 
 	// Execute our image (it should produce a JSON file with the list of files)
-	containerID, consoleOutput, err := p.docker.StartImage(dckr.ImageID(volumeFileListName), []string{filePath, "r"}, volumesToMount)
+	containerID, consoleOutput, err := p.docker.StartImage(dckr.ImageID(volumeFileListName), []string{filePath, "r"}, volumesToMount, p.limits)
 
 	if err != nil {
 		return volumeFileList, def.Err(err, "running image failed")

--- a/backend-docker/tests/pier_test.go
+++ b/backend-docker/tests/pier_test.go
@@ -19,7 +19,7 @@ func TestClient(t *testing.T) {
 	checkMsg(t, err, "reading config files")
 
 	db, err := db.InitDb()
-	pier, err := pier.NewPier(config.Docker, config.TmpDir, &db)
+	pier, err := pier.NewPier(config.Docker, config.TmpDir, config.Limits, &db)
 	checkMsg(t, err, "creating new pier")
 	defer db.Db.Close()
 
@@ -85,7 +85,7 @@ func TestExecution(t *testing.T) {
 	checkMsg(t, err, "reading config files")
 
 	db, err := db.InitDb()
-	pier, err := pier.NewPier(config.Docker, config.TmpDir, &db)
+	pier, err := pier.NewPier(config.Docker, config.TmpDir, config.Limits, &db)
 	checkMsg(t, err, "creating new pier")
 	defer db.Db.Close()
 

--- a/backend-docker/tests/server_test.go
+++ b/backend-docker/tests/server_test.go
@@ -21,7 +21,7 @@ func TestServer(t *testing.T) {
 	d, err := db.InitDb()
 
 	var p *pier.Pier
-	p, err = pier.NewPier(config.Docker, config.TmpDir, &d)
+	p, err = pier.NewPier(config.Docker, config.TmpDir, config.Limits, &d)
 	checkMsg(t, err, "creating new pier")
 	defer d.Db.Close()
 


### PR DESCRIPTION
Now it is possible to specify in config.json file how much resources docker containers are allowed to use (memory and CPU).