### PR TITLE
Dev server works over https correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ backend:
 	GEF_SECRET_KEY="test" go test -timeout 4m ./...
 
 run_webui_dev_server:
-	(cd $(WEBUI) && node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.config.devel.js)
+	(cd $(WEBUI) && node_modules/webpack-dev-server/bin/webpack-dev-server.js -d --hot --https --config webpack.config.devel.js)
 
 run_gef:
 	(cd backend-docker && go run main.go)

--- a/frontend/webui/webpack.config.devel.js
+++ b/frontend/webui/webpack.config.devel.js
@@ -30,7 +30,7 @@ module.exports = {
         historyApiFallback: true,
         proxy: {
             '/api/**': {
-                target :'http://localhost:4142',
+                target :'https://localhost:8443',
                 changeOrigin: true,
                 secure: false
             }


### PR DESCRIPTION
After moving from http to https the development server in Webpack stopped working. There was a problem with the redirection to the https address. Now the server runs in the https mode and everything works again.