### PR TITLE
More unified resource limitations

### DIFF
--- a/gefserver/main.go
+++ b/gefserver/main.go
@@ -20,6 +20,9 @@ func main() {
 	if err != nil {
 		log.Fatal("FATAL: ", err)
 	}
+	if config.Limits.CPUPeriod <= 0 {
+		log.Fatal("FATAL: ", def.Err(nil, "CPUPeriod is not set in the config file"))
+	}
 
 	d, err := db.InitDb()
 	if err != nil {

--- a/gefserver/pier/internal/dckr/dckr.go
+++ b/gefserver/pier/internal/dckr/dckr.go
@@ -467,6 +467,11 @@ func (c Client) CreateSwarmService(repoTag string, cmdArgs []string, binds []Vol
 
 		serviceMounts = append(serviceMounts, curMount)
 	}
+	if limits.CPUPeriod <= 0 {
+		return srv, &stdout, def.Err(nil, "CPUPeriod is not set in the config file")
+
+	}
+	calculatedNanoCPU := (limits.CPUQuota * 1e9) / limits.CPUPeriod
 
 	serviceCreateOpts := docker.CreateServiceOptions{
 		ServiceSpec: swarm.ServiceSpec{
@@ -477,12 +482,12 @@ func (c Client) CreateSwarmService(repoTag string, cmdArgs []string, binds []Vol
 					Command: cmdArgs,
 				},
 
-				/*Resources: &swarm.ResourceRequirements{
+				Resources: &swarm.ResourceRequirements{
 					Limits: &swarm.Resources{
-						//NanoCPUs:    10000,
-						MemoryBytes: limits.Memory*20000,
+						NanoCPUs:    calculatedNanoCPU,
+						MemoryBytes: limits.Memory,
 					},
-				},*/
+				},
 			},
 		},
 	}

--- a/gefserver/pier/internal/dckr/dckr.go
+++ b/gefserver/pier/internal/dckr/dckr.go
@@ -469,8 +469,10 @@ func (c Client) CreateSwarmService(repoTag string, cmdArgs []string, binds []Vol
 	}
 	if limits.CPUPeriod <= 0 {
 		return srv, &stdout, def.Err(nil, "CPUPeriod is not set in the config file")
-
 	}
+
+	/* Based on resources.CPUQuota = r.Limits.NanoCPUs * resources.CPUPeriod / 1e9
+	taken from https://github.com/moby/moby/blob/v1.12.0-rc4/daemon/cluster/executor/container/container.go#L331 */
 	calculatedNanoCPU := (limits.CPUQuota * 1e9) / limits.CPUPeriod
 
 	serviceCreateOpts := docker.CreateServiceOptions{

--- a/gefserver/pier/internal/dckr/dckr.go
+++ b/gefserver/pier/internal/dckr/dckr.go
@@ -467,9 +467,6 @@ func (c Client) CreateSwarmService(repoTag string, cmdArgs []string, binds []Vol
 
 		serviceMounts = append(serviceMounts, curMount)
 	}
-	if limits.CPUPeriod <= 0 {
-		return srv, &stdout, def.Err(nil, "CPUPeriod is not set in the config file")
-	}
 
 	/* Based on resources.CPUQuota = r.Limits.NanoCPUs * resources.CPUPeriod / 1e9
 	taken from https://github.com/moby/moby/blob/v1.12.0-rc4/daemon/cluster/executor/container/container.go#L331 */


### PR DESCRIPTION
Solves issue https://github.com/EUDAT-GEF/GEF/issues/106
Regular containers still have  more options for specifying allocated resources, but at least we do not have to add more properties to the config file: everything is calculated based on already existing values. I suggest to keep it that way