### PR TITLE
Script to generate TLS certificates, changes in the ReadMe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ for the system and therefore are not available by default (after the installatio
 understand how to build your own GEF services and how they work. If you want to use those services, you can build them
 through the web interface (by uploading corresponding Dockerfiles and image-related files).
 
-
 Database
 -------------
 The GEF is using an SQLite database to store the data. Using a different SQL database is possible.
@@ -40,12 +39,20 @@ Docker Swarm Mode
 -------------
 If you want to run GEF services on a Docker Swarm, you will need to create and configure it first. There is no need to install anything
 else, as long as you have Docker installed. `config.json` file has to be modified accordingly: endpoint should be changed
-to `tcp://[IP_ADDRESS_OF_THE_MANAGER_MACHINE]:2376` and `TLSVerify`, `CertPath`,
+to `tcp://[IP_ADDRESS_OF_THE_MANAGER_MACHINE]:[PORT_WHERE_DOCKER_IS_RUNNING]` and `TLSVerify`, `CertPath`,
 `KeyPath`, `CAPath` should be set in the `Docker` section of the config file.
-- This tutorial explains how it is done: https://rominirani.com/docker-swarm-tutorial-b67470cf8872
-- Follow the instructions at: https://docs.docker.com/engine/security/https/ to create certificates
-- If you created VMs using the docker-machine, you should put the certificates into `/var/lib/boot2docker/` folder on the
-swarm manager machine
-- `ca.pem`, `server-cert.pem`, and `server-key.pem` should be copied to the machine you are going to connect from
-- Use `docker --tlsverify --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem -H [IP_ADDRESS_OF_THE_MANAGER_MACHINE]:2376 info`
-to check if the connection is working.
+- This tutorial explains how to create a swarm: https://rominirani.com/docker-swarm-tutorial-b67470cf8872
+- Follow the instructions at: https://docs.docker.com/engine/security/https/ to create certificates or use the existing `tls.sh` script
+(which is much more convenient). 
+If you create a virtual machine in VirtualBox, you should configure the network properly:
+- Open `VirtualBox Manager`
+- Right click on a virtual machine and select `Settings`
+- Go to `Network` tab
+- First network adapter should be attached to `NAT`, the second one - to `Host-only adapter` (with the name `vboxnet1`)
+- Configure port forwarding for the first adapter similar to the following table:
+
+| Name | Protocol | Host IP | Host Port | Guest IP | Guest Port |
+| :---: |:--------:| :------:| :-------: | :------: | :---------: |
+| Daemon | TCP | 127.0.0.1 | 59047 | 10.0.2.15 | 2376 |
+| swarm | TCP | 127.0.0.1 | 59046 | 10.0.2.15 | 3024 |
+| ssh | TCP | 127.0.0.1 | 59045 |  | 22 |

--- a/tls.sh
+++ b/tls.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+echo "******************************************************************************************"
+echo "You are about to create certificates for the GEF. They will be saved at the current folder"
+echo "******************************************************************************************"
+echo "Follow the instructions!!!"
+read -r -p "Are you sure you want to continue? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY])
+        echo ""
+        echo "STEP 1: generate CA private and public keys"
+        echo "TIP: Common Name is your host name"
+        openssl genrsa -aes256 -out ca-key.pem 4096
+        openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -out ca.pem
+
+        echo ""
+        echo "STEP 2: create a server key and certificate signing request (CSR)"
+        openssl genrsa -out server-key.pem 4096
+        echo "Please enter the Common Name you have used above:"
+        read commonname
+        if [[ $commonname == "" ]]
+            then
+            echo "Common Name cannot be empty. Exiting"
+            exit 1
+        fi
+        openssl req -subj "/CN=$commonname" -sha256 -new -key server-key.pem -out server.csr
+
+        echo ""
+        echo "STEP 3: signing the public key with our CA"
+        echo "Since TLS connections can be made via IP address as well as DNS name, they need to be specified when creating the certificate."
+        echo "Please enter the IP address of your docker server machine. TIP: most likely it is one of those addresses:"
+        echo "$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')"
+        read ipaddress
+        if [[ $ipaddress == "" ]]
+            then
+            echo "IP address cannot be empty. Exiting"
+            exit 1
+        fi
+
+        echo subjectAltName = DNS:$commonname,IP:$ipaddress,IP:127.0.0.1 > extfile.cnf
+        openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -extfile extfile.cnf
+
+        echo ""
+        echo "STEP 4: client key and certificate signing request"
+        openssl genrsa -out key.pem 4096
+        openssl req -subj '/CN=client' -new -key key.pem -out client.csr
+
+
+        echo extendedKeyUsage = clientAuth > extfile.cnf
+        openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out cert.pem -extfile extfile.cnf
+
+        echo ""
+        echo "STEP 5: postprocessing"
+        rm -v client.csr server.csr
+        chmod -v 0400 ca-key.pem key.pem server-key.pem
+        chmod -v 0444 ca.pem server-cert.pem cert.pem
+        echo ""
+        echo "Congratulations! Now you have certificates. To make docker daemon more secure you can force it accept connections only form the clients with certificates:"
+        echo "dockerd --tlsverify --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem"
+        echo ""
+        echo "Now you can access docker from another machine, e.g. by using the command similar to this one (change the ip and port accordingly):"
+        echo "docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem -H=127.0.0.1:59047"
+        ;;
+    *)
+        echo "Operation has been cancelled"
+        ;;
+esac
+
+


### PR DESCRIPTION
I followed the instructions from https://docs.docker.com/engine/security/https/#create-a-ca-server-and-client-keys-with-openssl and created a script to automate the process