### PR TITLE
Fixed service build progress message problem

### DIFF
--- a/webui/src/components/Files.jsx
+++ b/webui/src/components/Files.jsx
@@ -82,7 +82,9 @@ class Files extends React.Component {
 
         const submitHandler = ()  => {
             fileUploadStart();
-            this.setState({ uploadInProgress: true, statusMessage: "Service is being built" });
+            if (this.state.myDropzone.files.length>0) {
+                this.setState({uploadInProgress: true, statusMessage: "Service is being built"});
+            }
             this.state.myDropzone.processQueue();
         };
 


### PR DESCRIPTION
The GEF was showing an incorrect progress message when the user did not choose any files and pressed "Build service" button. Now the animation is triggered only if at least one file has been selected.