### PR TITLE
Swarm service ID is returned after a service creation

### DIFF
--- a/gefserver/db/db.go
+++ b/gefserver/db/db.go
@@ -40,14 +40,15 @@ type JobTable struct {
 
 // TaskTable contains tasks related to a specific job (used to store data in a database)
 type TaskTable struct {
-	ID            string
-	Name          string
-	ContainerID   string
-	Error         string
-	ExitCode      int
-	ConsoleOutput string
-	Revision      int
-	JobID         string
+	ID             string
+	Name           string
+	ContainerID    string
+	SwarmServiceID string
+	Error          string
+	ExitCode       int
+	ConsoleOutput  string
+	Revision       int
+	JobID          string
 }
 
 // ServiceTable describes metadata for a GEF service (used to store data in a database)
@@ -198,6 +199,7 @@ func (d *Db) jobTable2Job(storedJob JobTable) (Job, error) {
 		curTask.Error = t.Error
 		curTask.ConsoleOutput = t.ConsoleOutput
 		curTask.ContainerID = ContainerID(t.ContainerID)
+		curTask.SwarmServiceID = t.SwarmServiceID
 		curTask.ExitCode = t.ExitCode
 		curTask.ID = t.ID
 		curTask.Name = t.Name
@@ -311,12 +313,13 @@ func (d *Db) SetJobOutputVolume(id JobID, outputVolume VolumeID) error {
 }
 
 // AddJobTask adds a task to a job
-func (d *Db) AddJobTask(id JobID, taskName string, taskContainer string,
+func (d *Db) AddJobTask(id JobID, taskName string, taskContainer string, taskSwarmService string,
 	taskError string, taskExitCode int, taskConsoleOutput *bytes.Buffer) error {
 	var newTask TaskTable
 	newTask.ID = uuid.New()
 	newTask.Name = taskName
 	newTask.ContainerID = string(taskContainer)
+	newTask.SwarmServiceID = taskSwarmService
 	newTask.Error = taskError
 	newTask.ExitCode = taskExitCode
 	newTask.ConsoleOutput = taskConsoleOutput.String()

--- a/gefserver/db/db.go
+++ b/gefserver/db/db.go
@@ -47,8 +47,8 @@ type TaskTable struct {
 	Error          string
 	ExitCode       int
 	ConsoleOutput  string
-	Revision       int
 	JobID          string
+	Revision       int
 }
 
 // ServiceTable describes metadata for a GEF service (used to store data in a database)
@@ -59,9 +59,9 @@ type ServiceTable struct {
 	RepoTag     string
 	Description string
 	Version     string
-	Revision    int
 	Created     time.Time
 	Size        int64
+	Revision    int
 }
 
 // IOPortTable is used to store info about service inputs and outputs in a database
@@ -70,8 +70,8 @@ type IOPortTable struct {
 	Name      string
 	Path      string
 	IsInput   bool
-	Revision  int
 	ServiceID string
+	Revision  int
 }
 
 // ServiceCmdTable stores CMD options for services
@@ -79,8 +79,8 @@ type ServiceCmdTable struct {
 	ID        int
 	Cmd       string
 	Index     int
-	Revision  int
 	ServiceID string
+	Revision  int
 }
 
 // UserTable is used to store the users in a database

--- a/gefserver/db/job.go
+++ b/gefserver/db/job.go
@@ -53,6 +53,7 @@ type Task struct {
 	ID            string
 	Name          string
 	ContainerID   ContainerID
+	SwarmServiceID  string
 	Error         string
 	ExitCode      int
 	ConsoleOutput string


### PR DESCRIPTION
Instead of looking for a service id by its container id, now we return a swarm service id immediately after it has been created.